### PR TITLE
Fix low call volume

### DIFF
--- a/audio/mixer_paths.xml
+++ b/audio/mixer_paths.xml
@@ -559,7 +559,8 @@
 	</path>
 
 	<path name="voice-handset">
-		<path name="handset" />
+		<path name="speaker" />
+		<ctl name="RX3 Digital Volume" value="70" />
 	</path>
 
 	<path name="voice-speaker">


### PR DESCRIPTION
No sound was played when answering a phone call. The other end could hear you speaking perfectly. Changing the volume made no difference.  

This fix was obtained from a [discussion in XDA forums](https://forum.xda-developers.com/moto-e-2015/help/low-call-volume-t3564645). I don't know if it's the correct way to deal with it, but it's definitely an improvement. It's working fine for over a week. No other bugs found so far.